### PR TITLE
Fix EventLogger payload shape

### DIFF
--- a/DataUpload_MQTT_Client.py
+++ b/DataUpload_MQTT_Client.py
@@ -1,17 +1,52 @@
 import paho.mqtt.client as mqtt
 import publishData
+import publishEvent
 
 # Määrittele MQTT-palvelimen tiedot
 MQTT_BROKER = "192.168.1.51"  # MQTT-välittäjän IP-osoite
 MQTT_PORT = 1883              # MQTT-oletusportti
-MQTT_TOPIC = "Datalogger/"    # Seurattava aihe
+MQTT_TOPICS = [
+    ("Datalogger/#", 0),
+    ("EventLogger/#", 0),
+]
+
+DATA_SHEET_NAME = "DataUpload2"
+EVENT_DEFAULT_SHEET = "EventLogger"
+
+
+def parse_payload(payload):
+    """Palauttaa viestistä poimitut arvot kokonaislukuina."""
+    start = payload.find('{')
+    end = payload.rfind('}')
+
+    if start != -1 and end != -1 and end > start:
+        payload_content = payload[start + 1:end]
+    else:
+        payload_content = payload
+
+    values = []
+    for value in payload_content.split(','):
+        stripped = value.strip()
+        if not stripped:
+            values.append(99)
+            continue
+
+        try:
+            values.append(int(stripped))
+        except ValueError as exc:
+            raise ValueError(
+                f"Sanoman arvo '{stripped}' ei ole kokonaisluku."
+            ) from exc
+
+    return values
 
 # Kun yhdistätään palvelimeen
 def on_connect(client, userdata, flags, rc):
     if rc == 0:
         print("Yhdistetty onnistuneesti MQTT-välittäjään.")
-        client.subscribe(MQTT_TOPIC)
-        print(f"Tilattu aihe: {MQTT_TOPIC}")
+        for topic, qos in MQTT_TOPICS:
+            client.subscribe(topic, qos=qos)
+            print(f"Tilattu aihe: {topic} QoS {qos}")
     else:
         print(f"Yhdistäminen epäonnistui. Palautekoodi: {rc}")
 
@@ -29,34 +64,31 @@ def on_message(client, userdata, msg):
         print(f"Payload: {payload}")
         print("-----------------------------")
 
-        topic_parts = msg.topic.split('/')  # Jaa aihe osiin
-        if len(topic_parts) >= 2:  # Varmistetaan, että aiheessa on riittävästi osia
-            device_name = topic_parts[1]  # Laitteen nimi toisena osana
-
-            # Poista aaltosulut ja jaa arvot pilkun perusteella
-            payload_cleaned = payload.strip('{}')
-            values = payload_cleaned.split(',')
-
-            # Korvataan puuttuvat arvot oletusarvolla 99
-            try:
-                int_values = [
-                    int(value.strip()) if value.strip() else 99
-                    for value in values
-                ]
-            except ValueError as ve:
-                print(f"Virhe: Sanoman arvot eivät ole kokonaislukuja. Virhe: {ve}")
-                return
-
-            # Tarkistetaan, että riittävästi arvoja käsitellään
-            dataset_size = len(int_values)
-            if dataset_size > 0 and dataset_size <= 40:  # Varmista, että datasetti mahtuu määritettyyn alueeseen
-                publishData.send_data(
-                    "DataUpload2", *int_values
-                )
-            else:
-                print(f"Virhe: Datasetin koko ({dataset_size}) ei ole hyväksyttävä: {payload}")
-        else:
+        topic_parts = [part for part in msg.topic.split('/') if part]
+        if not topic_parts:
             print(f"Virheellinen aihe: {msg.topic}")
+            return
+
+        base_topic = topic_parts[0]
+
+        try:
+            int_values = parse_payload(payload)
+        except ValueError as err:
+            print(f"Virhe: {err}")
+            return
+
+        dataset_size = len(int_values)
+        if dataset_size == 0 or dataset_size > 40:
+            print(f"Virhe: Datasetin koko ({dataset_size}) ei ole hyväksyttävä: {payload}")
+            return
+
+        if base_topic == "Datalogger":
+            publishData.send_data(DATA_SHEET_NAME, *int_values)
+        elif base_topic == "EventLogger":
+            sheet_name = topic_parts[1] if len(topic_parts) > 1 else EVENT_DEFAULT_SHEET
+            publishEvent.send_data(sheet_name, *int_values)
+        else:
+            print(f"Tuntematon aihe: {msg.topic}")
     except Exception as e:
         print(f"Virhe käsiteltäessä sanomaa: {e}")
 

--- a/publishEvent.py
+++ b/publishEvent.py
@@ -1,0 +1,41 @@
+import requests
+
+# Vakioarvot
+HOST = "https://script.google.com"
+SCRIPT_ID = "AKfycbyMvbyVtql9r3sGCPpy96RIc9fCt1Ja4w-OK2nx9W9wkd0zEEl_LaORH8Sz2N-cx8x2"
+URL = f"{HOST}/macros/s/{SCRIPT_ID}/exec"
+
+
+def _format_values(values):
+    """Palauta Apps Scriptin odottama pilkuin eroteltu merkkijono."""
+    return ",".join(str(value) for value in values)
+
+
+def send_data(sheet_name, *values):
+    """Lähetä tapahtumadata Google Apps Scriptille JSON-muodossa."""
+    if not sheet_name:
+        raise ValueError("sheet_name on annettava")
+
+    if len(values) < 7:
+        raise ValueError("EventLogger vaatii vähintään 7 arvoa")
+
+    payload = {
+        "sheet_name": sheet_name,
+        "values": _format_values(values),
+    }
+
+    headers = {"Content-Type": "application/json"}
+
+    try:
+        print(f"Connecting to {URL}...")
+        response = requests.post(URL, headers=headers, json=payload, timeout=30)
+
+        if response.status_code == 200:
+            print("Data published successfully.")
+            print("Response:", response.text)
+        else:
+            print(f"Failed to publish data. Status Code: {response.status_code}")
+            print("Response:", response.text)
+
+    except requests.exceptions.RequestException as err:
+        print(f"Connection failed: {err}")


### PR DESCRIPTION
## Summary
- update `publishEvent.send_data` to accept the sheet name from the caller and validate that at least seven event values are provided
- format the `values` field exactly as the EventLogger Google Apps Script expects while preserving the provided script identifier

## Testing
- python -m compileall publishEvent.py

------
https://chatgpt.com/codex/tasks/task_e_68ca62b0506c8322a5bec53ffeece64a