### PR TITLE
Add payload logging and align event parsing

### DIFF
--- a/EventLogger_GS.js
+++ b/EventLogger_GS.js
@@ -11,6 +11,9 @@ function doPost(e) {
       return jsonOut({ ok: false, error: "no_postdata" });
     }
 
+    console.log("[EventLogger] Payload: " + e.postData.contents);
+    Logger.log("[EventLogger] Payload: %s", e.postData.contents);
+
     var parsed;
     try {
       parsed = JSON.parse(e.postData.contents);

--- a/EventLogger_MQTT_Client.py
+++ b/EventLogger_MQTT_Client.py
@@ -1,56 +1,105 @@
 import json
-from typing import Any, Dict, List, Union
+import re
+from typing import Any, Dict, Iterable, List, Optional
 
 import paho.mqtt.client as mqtt
 import publishEvent
+from payload_logger import log_payload
 
 MQTT_BROKER = "192.168.1.51"
 MQTT_PORT = 1883
 MQTT_TOPIC = "EventLogger/#"
 
 
-ParsedEvent = Union[Dict[str, Any], List[str], str]
+EXPECTED_VALUE_COUNT = 7
+
+FIELD_ALIASES = {
+    "rssi": ("rssi", "signal", "signal_strength"),
+    "priority": ("priority", "prio", "severity"),
+    "device": ("device", "device_id", "device_ip", "ip"),
+    "event_code": ("event_code", "code", "event", "eventid"),
+    "event_word": ("event_word", "word"),
+    "event_value": ("event_value", "value", "eventvalue"),
+    "extra": ("extra", "extra_value", "addition", "payload"),
+}
 
 
-def parse_event_payload(payload: str) -> ParsedEvent:
-    """Parse incoming payload for event logging."""
+def _coerce_to_int(value: Any, field_name: str) -> int:
+    if value is None:
+        return 0
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, (int, float)):
+        return int(value)
+
+    text = str(value).strip()
+    if not text:
+        return 0
+
+    try:
+        return int(text, 10)
+    except ValueError:
+        log_payload(
+            "EventLogger_MQTT_Client",
+            f"Ei-numeerinen arvo '{value}' kentässä {field_name}, käytetään 0",
+            context="value_conversion",
+        )
+        return 0
+
+
+def _values_from_dict(data: Dict[str, Any], event_identifier: Optional[str]) -> List[int]:
+    values: List[int] = []
+    for field, aliases in FIELD_ALIASES.items():
+        selected = next((data.get(alias) for alias in aliases if alias in data), None)
+        if field == "event_code" and selected is None and event_identifier is not None:
+            selected = event_identifier
+        values.append(_coerce_to_int(selected, field))
+    return values
+
+
+def _ensure_length(values: Iterable[int]) -> List[int]:
+    normalized = list(values)
+    if len(normalized) < EXPECTED_VALUE_COUNT:
+        normalized.extend([0] * (EXPECTED_VALUE_COUNT - len(normalized)))
+    elif len(normalized) > EXPECTED_VALUE_COUNT:
+        normalized = normalized[:EXPECTED_VALUE_COUNT]
+    return normalized
+
+
+def parse_event_payload(payload: str, event_identifier: Optional[str] = None) -> List[int]:
+    """Parse incoming payload into the numeric format expected by the Apps Script."""
+
     payload = payload.strip()
     if not payload:
-        return {}
+        raise ValueError("Tyhjä payload")
 
+    data: Any
     try:
         data = json.loads(payload)
     except json.JSONDecodeError:
         data = None
 
     if isinstance(data, dict):
-        return data
+        return _ensure_length(_values_from_dict(data, event_identifier))
+
     if isinstance(data, list):
-        return {"events": data}
-    if data is not None:
-        return {"value": data}
+        return _ensure_length(_coerce_to_int(value, f"list[{index}]") for index, value in enumerate(data))
 
-    # Fallback: try key-value pairs separated by ';' or ','
-    separators = [';', ',']
-    segments: List[str] = [payload]
-    for separator in separators:
-        if separator in payload:
-            segments = [segment.strip() for segment in payload.split(separator) if segment.strip()]
-            break
+    separators = ",;\t"
+    if any(sep in payload for sep in separators):
+        parts = [part.strip() for part in re.split(r"[,;\t]", payload) if part.strip()]
+    else:
+        parts = [payload]
 
-    event_data: Dict[str, Any] = {}
-    for segment in segments:
-        if '=' in segment:
-            key, value = segment.split('=', 1)
-            event_data[key.strip()] = value.strip()
+    values = [_coerce_to_int(value, f"segment[{index}]") for index, value in enumerate(parts)]
 
-    if event_data:
-        return event_data
+    if event_identifier and len(values) < EXPECTED_VALUE_COUNT:
+        event_code = _coerce_to_int(event_identifier, "event_identifier")
+        while len(values) < 4:
+            values.append(0)
+        values[3] = event_code
 
-    if len(segments) > 1:
-        return segments
-
-    return payload
+    return _ensure_length(values)
 
 
 # MQTT callbacks
@@ -72,10 +121,12 @@ def on_message(client, userdata, msg):
             payload = msg.payload.decode("utf-8")
         except UnicodeDecodeError as ude:
             print(f"Failed to decode payload: {ude}")
+            log_payload("EventLogger_MQTT_Client", f"Decode failed: {ude}", context=msg.topic)
             return
 
         print(f"Payload: {payload}")
         print("=============================")
+        log_payload("EventLogger_MQTT_Client", payload, context=msg.topic)
 
         topic_parts = msg.topic.split('/')
         device_name = topic_parts[1] if len(topic_parts) >= 2 and topic_parts[1] else "EventLogger"
@@ -84,25 +135,19 @@ def on_message(client, userdata, msg):
         else:
             event_identifier = None
 
-        event_data = parse_event_payload(payload)
-
-        if isinstance(event_data, dict):
-            if event_identifier and "event" not in event_data:
-                event_data["event"] = event_identifier
-            publishEvent.send_data(device_name, event_data)
+        try:
+            event_values = parse_event_payload(payload, event_identifier)
+        except ValueError as exc:
+            print(f"Error parsing event payload: {exc}")
+            log_payload("EventLogger_MQTT_Client", f"Parsing error: {exc}", context=msg.topic)
             return
 
-        if isinstance(event_data, (list, tuple)):
-            values: List[str] = [str(value) for value in event_data]
-        elif event_data is None:
-            values = []
-        else:
-            values = [str(event_data)]
-
-        if event_identifier:
-            values.insert(0, event_identifier)
-
-        publishEvent.send_data(device_name, *values)
+        publishEvent.send_data(device_name, *event_values)
+        log_payload(
+            "EventLogger_MQTT_Client",
+            f"Forwarded values: {event_values}",
+            context=device_name,
+        )
     except Exception as exc:
         print(f"Error handling event message: {exc}")
 

--- a/payload_logger.py
+++ b/payload_logger.py
@@ -1,0 +1,42 @@
+"""Utility for consistent payload logging across scripts."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+_LOGGER_NAME = "payload_logger"
+_LOG_FILE = Path(__file__).with_name("payloads.log")
+
+
+def _get_logger() -> logging.Logger:
+    """Configure (once) and return the shared payload logger."""
+    logger = logging.getLogger(_LOGGER_NAME)
+    if not logger.handlers:
+        logger.setLevel(logging.INFO)
+        handler = logging.FileHandler(_LOG_FILE, encoding="utf-8")
+        formatter = logging.Formatter(
+            fmt="%(asctime)s\t%(levelname)s\t%(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S",
+        )
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+        logger.propagate = False
+    return logger
+
+
+def log_payload(source: str, payload: object, context: Optional[str] = None) -> None:
+    """Write payload information to the shared log file.
+
+    Args:
+        source: Name of the caller (script/module).
+        payload: Payload data to be logged.
+        context: Optional additional context (e.g. MQTT topic).
+    """
+    logger = _get_logger()
+    payload_text = str(payload)
+    if context:
+        logger.info("%s | %s | %s", source, context, payload_text)
+    else:
+        logger.info("%s | %s", source, payload_text)

--- a/publishData.py
+++ b/publishData.py
@@ -1,6 +1,8 @@
 import requests
 import json
 
+from payload_logger import log_payload
+
 # Vakioarvot
 HOST = "https://script.google.com"
 SCRIPT_ID = "AKfycbwnmiItP_1NRe0ER6dogBr29-qXEC97CUkgAK6nly3gn8IjlFxAE9FwUxA2ss0JaruFjA"  # Korvaa omalla Google Script ID:lläsi
@@ -20,6 +22,8 @@ def send_data(device_name, *values):
         "command": "insert_row"
     }
 
+    log_payload("publishData", payload)
+
     headers = {"Content-Type": "application/json"}
 
     try:
@@ -30,12 +34,18 @@ def send_data(device_name, *values):
         if response.status_code == 200:
             print("Data published successfully.")
             print("Response:", response.text)
+            log_payload("publishData", f"Success: {response.text}")
         else:
             print(f"Failed to publish data. Status Code: {response.status_code}")
             print("Response:", response.text)
+            log_payload(
+                "publishData",
+                f"Failure {response.status_code}: {response.text}",
+            )
 
     except requests.exceptions.RequestException as e:
         print(f"Connection failed: {e}")
+        log_payload("publishData", f"Connection failed: {e}")
 
 # Esimerkki kutsu
 # send_data("DataUpload2", 1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000, 10000)

--- a/publishEvent.py
+++ b/publishEvent.py
@@ -2,6 +2,8 @@ import json
 import requests
 from typing import Any
 
+from payload_logger import log_payload
+
 HOST = "https://script.google.com"
 # Valitse tähän se oikea oman Apps Script -julkaisusi ID:
 SCRIPT_ID = "AKfycbwzZCJKv3pyLBs3dSVUgYUYwQPKIS5atRKHsvxcFNSNJTDVg51MisQtZW0EGYmvTfzp6g"
@@ -36,6 +38,8 @@ def send_data(sheet_name: str,
         "values": value_string,
     }
 
+    log_payload("publishEvent", payload)
+
     headers = {"Content-Type": "application/json"}
 
     try:
@@ -45,8 +49,14 @@ def send_data(sheet_name: str,
             print(payload)
             print("Event data published successfully.")
             print("Response:", response.text)
+            log_payload("publishEvent", f"Success: {response.text}")
         else:
             print(f"Failed to publish event data. Status Code: {response.status_code}")
             print("Response:", response.text)
+            log_payload(
+                "publishEvent",
+                f"Failure {response.status_code}: {response.text}",
+            )
     except requests.exceptions.RequestException as exc:
         print(f"Connection failed: {exc}")
+        log_payload("publishEvent", f"Connection failed: {exc}")


### PR DESCRIPTION
## Summary
- add a shared payload logging helper and use it in both MQTT clients and HTTP publishers
- normalise EventLogger MQTT payload parsing to produce the data shape expected by the Google Apps Script endpoint
- log inbound payloads in the Google Apps Script for easier troubleshooting

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68cd864e7b28832297810f3c59860b8f